### PR TITLE
Add shell script and Dockerfile modification to build psql in the Sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN apt-get update && apt-get install -y \
     python-pip \
     python-psycopg2
 
+# Install psql client tools
+COPY pg-client-install.sh /tmp/
+RUN /tmp/pg-client-install.sh
+
+
 RUN mkdir /var/run/sshd
 RUN echo 'root:sandbox' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
 # Install psql client tools
 
 COPY psql-client-install.sh /tmp/
+RUN chmod u+x /tmp/psql-client-install.sh
 RUN /tmp/psql-client-install.sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN apt-get update && apt-get install -y \
     python-pip \
     python-psycopg2
 
+# Install psql client tools
+COPY psql-client-install.sh /tmp/
+RUN /tmp/pg-client-install.sh
+
+
 RUN mkdir /var/run/sshd
 RUN echo 'root:sandbox' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config

--- a/psql-client-install.sh
+++ b/psql-client-install.sh
@@ -7,4 +7,4 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
   sudo apt-key add -
 
 # Update the package lists, and install psql client
-sudo apt-get update && apt-get install postgresql-client-9.4
+sudo apt-get update && apt-get install -y postgresql-client-9.4

--- a/psql-client-install.sh
+++ b/psql-client-install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Add add a line for the Postgres repository
+echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+# Import the repository signing key
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+  sudo apt-key add -
+
+# Update the package lists, and install psql client
+sudo apt-get update && apt-get install postgresql-client-9.4


### PR DESCRIPTION
As we discussed in Slack, this adds the `psql` command line Postgres client to the image, by means of copying in a small shell script and running it. (The script is because there are a couple of preliminary commands needed in order to add the pgsql apt repo to the update lists.)
